### PR TITLE
Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - run: sudo rm -f /var/lib/man-db/auto-update  # Workaround for https://github.com/actions/runner/issues/4030
+    - run: sudo apt-get install --yes gperf
+    - run: autoconf
+    - run: ./configure
+    - run: make


### PR DESCRIPTION
# DO NOT MERGE

This is a draft proposal for CI using Github Actions.

Right now, it does a basic `autoconf && ./configure && make`; but, I strongly suspect this is insufficient as there are several configuration options we undoubtedly want to set to get full code coverage in compilation. A matrix of them, no doubt!

I just don't know what that matrix would be. @wrog, thoughts?

Some future work would be to import and run the [old test suite](https://wrog.net/moo/test.tar.gz) and [m5 test suite](https://github.com/wrog/m5.git).